### PR TITLE
Add Aguara, Aguara MCP, and Oktsec to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ MCP servers for security operations, vulnerability scanning, and threat detectio
 - [securityfortech/secops-mcp](https://github.com/securityfortech/secops-mcp) 🐍 🏠 - All-in-one security testing toolbox that brings together popular open source tools through a single MCP interface. Connected to an AI agent, it enables tasks like pentesting, bug bounty hunting, threat hunting, and more.
 - [roadwy/cve-search_mcp](https://github.com/roadwy/cve-search_mcp) 🐍 🏠 - A Model Context Protocol (MCP) server for querying the CVE-Search API. This server provides comprehensive access to CVE-Search, browse vendor and product、get CVE per CVE-ID、get the last updated CVEs.
 - [nickpending/mcp-recon](https://github.com/nickpending/mcp-recon) 🏎️ 🏠 - Conversational recon interface and MCP server powered by httpx and asnmap. Supports various reconnaissance levels for domain analysis, security header inspection, certificate analysis, and ASN lookup.
+- [garagon/aguara](https://github.com/garagon/aguara) 🏎️ 🏠 - Static security scanner for AI agent skills and MCP servers. 148 detection rules across 13 categories. Offline, deterministic, no LLM dependency. Single Go binary.
+- [garagon/aguara-mcp](https://github.com/garagon/aguara-mcp) 🏎️ 🏠 - MCP server that gives AI agents security scanning capabilities via Aguara. Agents can scan skills and configs for threats before installing them.
+- [oktsec/oktsec](https://github.com/oktsec/oktsec) 🏎️ 🏠 - Security proxy for AI agent-to-agent communication. Ed25519 identity, policy enforcement, 169 detection rules, and audit trail. OWASP Top 10 for LLM aligned.
 
 ## CI/CD & DevOps Pipelines
 


### PR DESCRIPTION
## Summary

Adds three security-focused projects to the 🔒 Security section:

- **[garagon/aguara](https://github.com/garagon/aguara)** — Static security scanner for AI agent skills and MCP servers. 148 detection rules across 13 categories. Offline, deterministic, no LLM dependency. Single Go binary.
- **[garagon/aguara-mcp](https://github.com/garagon/aguara-mcp)** — MCP server that gives AI agents security scanning capabilities via Aguara. Agents can scan skills and configs for threats before installing them.
- **[oktsec/oktsec](https://github.com/oktsec/oktsec)** — Security proxy for AI agent-to-agent communication. Ed25519 identity, policy enforcement, 169 detection rules, and audit trail. OWASP Top 10 for LLM aligned.

All three are open-source Go projects focused on securing the MCP/AI agent ecosystem.