### PR TITLE
Add ATR (Agent Threat Rules) — open-source detection rules for MCP threats

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 
 ## 🧑‍🚀 Tools and code
 
-- [ATR (Agent Threat Rules) - Open-source detection rules for AI agent threats (prompt injection, tool poisoning, data exfiltration). 71 rules, OWASP Agentic Top 10 coverage, PINT benchmarked](https://github.com/Agent-Threat-Rule/agent-threat-rules)
+- [ATR (Agent Threat Rules) - Open-source detection rules for AI agent threats (prompt injection, tool poisoning, data exfiltration). 108 rules, OWASP Agentic Top 10 coverage, Shipped in Cisco AI Defense. 53K skills scanned, 0% FP. PINT benchmarked](https://github.com/Agent-Threat-Rule/agent-threat-rules)
 - [MCP Audit Extension - Audit and log all GitHub Copilot MCP tool calls in VSCode with ease](https://github.com/Agentity-com/mcp-audit-extension)
 - [Secure MCP - Security auditing tool to detect MCP vulnerabilities and misconfigurations by makalin](https://github.com/makalin/SecureMCP)
 - [mcp-context-protector - Security wrapper for MCP servers by trailofbits](https://github.com/trailofbits/mcp-context-protector)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 
 ## 🧑‍🚀 Tools and code
 
-- [ATR (Agent Threat Rules) - Open-source detection rules for AI agent threats (prompt injection, tool poisoning, data exfiltration). 108 rules, OWASP Agentic Top 10 coverage, Shipped in Cisco AI Defense. 53K skills scanned, 0% FP. PINT benchmarked](https://github.com/Agent-Threat-Rule/agent-threat-rules)
+- [ATR (Agent Threat Rules) - MIT-licensed open detection-rule standard for AI agent and MCP threats (prompt injection, tool poisoning, context exfiltration, skill supply-chain compromise). Sigma/YARA-style YAML rules with OWASP Agentic Top 10, MITRE ATLAS and SAFE-MCP crosswalks; the rule pack ships in Cisco AI Defense skill-scanner. Benchmarks are published upstream, version-pinned per measurement](https://github.com/Agent-Threat-Rule/agent-threat-rules)
 - [MCP Audit Extension - Audit and log all GitHub Copilot MCP tool calls in VSCode with ease](https://github.com/Agentity-com/mcp-audit-extension)
 - [Secure MCP - Security auditing tool to detect MCP vulnerabilities and misconfigurations by makalin](https://github.com/makalin/SecureMCP)
 - [mcp-context-protector - Security wrapper for MCP servers by trailofbits](https://github.com/trailofbits/mcp-context-protector)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 
 ## 🧑‍🚀 Tools and code
 
+- [ATR (Agent Threat Rules) - Open-source detection rules for AI agent threats (prompt injection, tool poisoning, data exfiltration). 71 rules, OWASP Agentic Top 10 coverage, PINT benchmarked](https://github.com/Agent-Threat-Rule/agent-threat-rules)
 - [MCP Audit Extension - Audit and log all GitHub Copilot MCP tool calls in VSCode with ease](https://github.com/Agentity-com/mcp-audit-extension)
 - [Secure MCP - Security auditing tool to detect MCP vulnerabilities and misconfigurations by makalin](https://github.com/makalin/SecureMCP)
 - [mcp-context-protector - Security wrapper for MCP servers by trailofbits](https://github.com/trailofbits/mcp-context-protector)


### PR DESCRIPTION
## Update (April 2026)

ATR has grown significantly since this PR was first submitted:

- **108 detection rules** across 9 threat categories (v1.1.1 on npm)
- **Adopted by Cisco AI Defense** — 34 rules merged into official skill-scanner ([PR #79](https://github.com/cisco-ai-defense/skill-scanner/pull/79))
- **Threat Cloud live** — 14,979 skill threats processed, 47 rule proposals crystallized
- **PRs pending** at NVIDIA Garak (7.5K stars) and Promptfoo (19.7K stars)
- **Benchmarks**: 96.9% recall / 100% precision on SKILL.md (498 samples), 99.7% precision on MCP (850 samples)
- Install: `npm install agent-threat-rules && npx atr scan .`

---
## What is ATR?

[Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) is an open-source set of detection rules for AI agent security threats — like YARA/Sigma rules, but for MCP and LLM tool-calling attacks.

### Key stats

- **71 rules** across 9 categories (prompt injection, tool poisoning, data exfiltration, credential theft, sandbox escape, etc.)
- **62.7% recall / 99.7% precision** on [PINT benchmark](https://github.com/lakeraai/pint-benchmark)
- **OWASP Agentic Top 10: 10/10 coverage** ([mapping](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/OWASP-MAPPING.md))
- **SAFE-MCP: 91.8% coverage** ([mapping](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/SAFE-MCP-MAPPING.md))
- TypeScript + Python engines, Splunk/Elastic query converters
- MIT licensed, community-driven

### Why it fits this list

ATR provides the detection layer that complements the MCP security tools already listed here. While other tools focus on runtime protection or auditing, ATR gives the community a shared set of threat patterns that any tool can import and use.

### Ecosystem scan

We scanned 36,394 ClawHub skills using ATR — found 182 CRITICAL / 1,124 HIGH findings. Full report: https://panguard.ai/research/mcp-ecosystem-scan