### PR TITLE
Add Not Human Search verify_mcp (live JSON-RPC probe) to Tools and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Awesome Cybersecurity Agentic AI](https://github.com/raphabot/awesome-cybersecurity-agentic-ai) - Collection of resources on using AI agents for security use cases
 - (31.03.2025) [I gave Claude root access to my server... Model Context Protocol explained by Fireship](https://www.youtube.com/watch?v=HyzlYwjoXOQ)
 - (17.03.2025) [Model Context Protocol (MCP): The Key To Agentic AI by Jack Herrington](https://www.youtube.com/watch?v=VChRPFUzJGA)
+- [Not Human Search `verify_mcp`](https://nothumansearch.ai/score) - Live JSON-RPC probe that tests whether an MCP server is reachable and returns valid responses. Useful as a dynamic reachability check alongside static security scanners. Free API endpoint: `GET /score?domain=<host>`.
 - [Official MCP Specification](https://modelcontextprotocol.io/specification/2025-03-26/server/tools)
 - [Model Context Protocol - Official MCP website](https://modelcontextprotocol.io/) 
 


### PR DESCRIPTION
Adds [Not Human Search's `verify_mcp` tool](https://nothumansearch.ai/mcp) to the **🧑‍🚀 Tools and code** section.

**Framed specifically as a security-adjacent tool:** `verify_mcp` is a live JSON-RPC probe exposed via an MCP endpoint. It confirms an advertised `/mcp` endpoint actually responds to `initialize` — useful as a dynamic complement to the static scanners already listed (MCP Watch, mcp-scan, etc.).

**Use case:** before trusting an MCP server listed in a directory, call NHS's `verify_mcp` tool with that URL. If it returns a proper JSON-RPC handshake, the server is actually reachable and speaks the current protocol version. Many servers in public directories are dead or speak outdated protocol.

- Live: https://nothumansearch.ai/mcp
- How to install: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`
- Source: https://github.com/unitedideas/nothumansearch (MIT)
- Official MCP registry: `ai.nothumansearch/search`