### PR TITLE
Add Not Human Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 
 ## 🧑‍🚀 Tools and code
 
+- [Not Human Search](https://nothumansearch.ai) - Agent-readiness scanner with live MCP endpoint verification and discovery-surface checks.
 - [MCP Audit Extension - Audit and log all GitHub Copilot MCP tool calls in VSCode with ease](https://github.com/Agentity-com/mcp-audit-extension)
 - [Secure MCP - Security auditing tool to detect MCP vulnerabilities and misconfigurations by makalin](https://github.com/makalin/SecureMCP)
 - [mcp-context-protector - Security wrapper for MCP servers by trailofbits](https://github.com/trailofbits/mcp-context-protector)


### PR DESCRIPTION
Adds Not Human Search to the Tools and code section.\n\nIt fits because it checks agent-readable discovery surfaces and performs live MCP endpoint verification, which helps teams validate whether MCP-capable services are actually discoverable and callable by agents.