### PR TITLE
Add bulwark-mcp to Tools and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Octocode](https://github.com/bgauryy/octocode-mcp) - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem. Allow smart search of security patterns across repositories.
 - [Defenter](https://defenter.ai/) - Real-time semantic monitoring of AI coding agents and MCP server communication to protect from data leaks, context contamination, and malicious prompt injections.
 - [MCP-Dandan](https://github.com/82ch/MCP-Dandan) - Desktop security tool for real-time monitoring, threat detection, and control of MCP tool invocations.
+- [bulwark-mcp](https://github.com/churik5/bulwark-mcp) - Local stdio proxy that detects and blocks indirect prompt injection in MCP tool results before they reach the agent. Layered defense (regex, optional local LLM, YAML policy), fully local, no telemetry.
 
 ## 💾 MCP Security Servers
 - [Nuclei MCP Integration by addcontent](https://github.com/addcontent/nuclei-mcp) - Provides a standardized MCP interface for Nuclei, a fast and customizable vulnerabilty scanner, for performing scans and managing vulnerablity assessments


### PR DESCRIPTION
Adds bulwark-mcp - a local stdio proxy that detects/blocks indirect prompt injection in MCP tool results before the agent reads them. MCP-specific (understands JSON-RPC, tools/call vs tools/list), fully local, no telemetry. Fits "Tools and code" alongside MCP Defender / MCP-Dandan.

AGPL-3.0, Python. Repo: https://github.com/churik5/bulwark-mcp