### PR TITLE
Add fak (Fused Agent Kernel) to Tools and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Octocode](https://github.com/bgauryy/octocode-mcp) - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem. Allow smart search of security patterns across repositories.
 - [Defenter](https://defenter.ai/) - Real-time semantic monitoring of AI coding agents and MCP server communication to protect from data leaks, context contamination, and malicious prompt injections.
 - [MCP-Dandan](https://github.com/82ch/MCP-Dandan) - Desktop security tool for real-time monitoring, threat detection, and control of MCP tool invocations.
-- [fak (Fused Agent Kernel) - default-deny gate that adjudicates every agent / MCP tool call and quarantines tool results to contain prompt-injection and tool-poisoning, by anthony-chaudhary](https://github.com/anthony-chaudhary/fak)
+- [fak (Fused Agent Kernel)](https://github.com/anthony-chaudhary/fak) - default-deny gate that adjudicates every agent / MCP tool call and quarantines tool results out of the model's context to contain prompt-injection and tool-poisoning, by anthony-chaudhary
 
 ## 💾 MCP Security Servers
 - [Nuclei MCP Integration by addcontent](https://github.com/addcontent/nuclei-mcp) - Provides a standardized MCP interface for Nuclei, a fast and customizable vulnerabilty scanner, for performing scans and managing vulnerablity assessments

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Octocode](https://github.com/bgauryy/octocode-mcp) - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem. Allow smart search of security patterns across repositories.
 - [Defenter](https://defenter.ai/) - Real-time semantic monitoring of AI coding agents and MCP server communication to protect from data leaks, context contamination, and malicious prompt injections.
 - [MCP-Dandan](https://github.com/82ch/MCP-Dandan) - Desktop security tool for real-time monitoring, threat detection, and control of MCP tool invocations.
+- [fak (Fused Agent Kernel) - default-deny gate that adjudicates every agent / MCP tool call and quarantines tool results to contain prompt-injection and tool-poisoning, by anthony-chaudhary](https://github.com/anthony-chaudhary/fak)
 
 ## 💾 MCP Security Servers
 - [Nuclei MCP Integration by addcontent](https://github.com/addcontent/nuclei-mcp) - Provides a standardized MCP interface for Nuclei, a fast and customizable vulnerabilty scanner, for performing scans and managing vulnerablity assessments


### PR DESCRIPTION
Adds [fak](https://github.com/anthony-chaudhary/fak) to the Tools and code section.

**fak** is an agent kernel — a Go binary that adjudicates every agent / MCP tool call before it runs: a default-deny capability gate the model can't talk past, and tool-poisoning containment that quarantines tool results out of the model's context so an injected instruction can't escalate capability. Apache-2.0, zero external deps. Sits alongside MCP Guardian, mcp-context-protector, and MCP Defender.

Entry follows the section's existing `[Name - description by author](url)` format, appended to the list.