### PR TITLE
Add AgentX (agentx-mcp) to Tools and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Octocode](https://github.com/bgauryy/octocode-mcp) - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem. Allow smart search of security patterns across repositories.
 - [Defenter](https://defenter.ai/) - Real-time semantic monitoring of AI coding agents and MCP server communication to protect from data leaks, context contamination, and malicious prompt injections.
 - [MCP-Dandan](https://github.com/82ch/MCP-Dandan) - Desktop security tool for real-time monitoring, threat detection, and control of MCP tool invocations.
+- [AgentX](https://agentx-core.com) - Keyless stdio proxy that wraps any MCP server and blocks catastrophic tool calls (destructive SQL, SSRF, secret/PII reads, rm -rf, path traversal) before they reach the server, then coaches the agent to a safe retry so the run survives instead of dying on a 403. One line in mcp.json, no key.
 
 ## 💾 MCP Security Servers
 - [Nuclei MCP Integration by addcontent](https://github.com/addcontent/nuclei-mcp) - Provides a standardized MCP interface for Nuclei, a fast and customizable vulnerabilty scanner, for performing scans and managing vulnerablity assessments

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Official Security Considerations from the [Official MCP Specification Rev: 2025-
 - [Octocode](https://github.com/bgauryy/octocode-mcp) - AI-powered developer assistant that enables advanced research, analysis and discovery across GitHub ecosystem. Allow smart search of security patterns across repositories.
 - [Defenter](https://defenter.ai/) - Real-time semantic monitoring of AI coding agents and MCP server communication to protect from data leaks, context contamination, and malicious prompt injections.
 - [MCP-Dandan](https://github.com/82ch/MCP-Dandan) - Desktop security tool for real-time monitoring, threat detection, and control of MCP tool invocations.
-- [AgentX](https://agentx-core.com) - Keyless stdio proxy that wraps any MCP server and blocks catastrophic tool calls (destructive SQL, SSRF, secret/PII reads, rm -rf, path traversal) before they reach the server, then coaches the agent to a safe retry so the run survives instead of dying on a 403. One line in mcp.json, no key.
+- [AgentX](https://agentx-core.com) - Keyless stdio proxy: wrap any MCP server in one line of mcp.json and it blocks catastrophic tool calls (destructive SQL, SSRF, secret/PII reads, rm -rf, path traversal) before they reach the server, and keeps the agent's run alive instead of dying on the block. No API key, nothing leaves your machine.
 
 ## 💾 MCP Security Servers
 - [Nuclei MCP Integration by addcontent](https://github.com/addcontent/nuclei-mcp) - Provides a standardized MCP interface for Nuclei, a fast and customizable vulnerabilty scanner, for performing scans and managing vulnerablity assessments


### PR DESCRIPTION
Adds **AgentX** to the Tools and code section.

`agentx-mcp` (ships in `pip install agentx-security-sdk`) is a keyless stdio proxy: wrap any MCP server with one line in `mcp.json` and it screens every `tools/call` before it runs. It blocks the catastrophic classes deterministically (destructive SQL, SSRF to cloud metadata, secret/PII reads, `rm -rf`, path traversal) with no API key and nothing leaving the machine.

The part that differs from most entries here: on a block it returns a **coaching** tool error rather than a dead 403, so the calling model reads it, revises, and the run continues instead of dying on the block.

- Site + live demo: https://agentx-core.com
- PyPI: https://pypi.org/project/agentx-security-sdk/